### PR TITLE
Even more GYU0 TryCompressPrevious optimizations

### DIFF
--- a/SkyEditor.RomEditor.Rtdx/Domain/Common/Structures/Gyu0.cs
+++ b/SkyEditor.RomEditor.Rtdx/Domain/Common/Structures/Gyu0.cs
@@ -8,6 +8,13 @@ namespace SkyEditor.RomEditor.Domain.Common.Structures
 {
     public static class Gyu0
     {
+
+#if DEBUG
+        const int LookbehindDistance = 0x100;
+#else
+        const int LookbehindDistance = 0x400;
+#endif
+
         private enum Opcode
         {
             Copy,
@@ -310,7 +317,7 @@ namespace SkyEditor.RomEditor.Domain.Common.Structures
                 matchPos = -1;
                 matchLength = 0;
 
-                var maxLookbehindDistance = Math.Min(0x400, (int)offset);
+                var maxLookbehindDistance = Math.Min(LookbehindDistance, (int)offset);
                 if (maxLookbehindDistance < 2) return;
                 var maxLength = Math.Min(33, (int)Math.Min(maxLookbehindDistance, data.Length - offset));
                 if (maxLength < 2) return;


### PR DESCRIPTION
This rewrite takes inspiration from existing LZ77 implementations in that it uses a hash chain to keep track of the positions where every pair of bytes has been seen in the stream to speed up lookups. The chain allows quick backwards traversal to other matches of a given pair of bytes. It also has optimizations for the very common case of strings starting with a sequence of repeated bytes, which again provides a large speed boost.

The new times are in the range of 2000-2200 ms on my machine. For reference, the same tests take ~1100 ms on average when disabling TryCompressPrevious.